### PR TITLE
README.md: Add optional forbid(unsafe_code)/badge recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Our process is as follows:
     are filled in.
 4) Once a crate has been gone over enough we close that issue. If the crate
    needs re-checking again later on we just open a new issue.
-5) (optional) If you have completely cleansed a crate of `unsafe`, add a
+5) (Optional) If you have completely cleansed a crate of `unsafe`, add a
    `#![forbid(unsafe_code)]` attribute to its `src/lib.rs` or `main.rs`
    and/or an ![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)
    badge to its README.md. Markdown:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Our process is as follows:
     are filled in.
 4) Once a crate has been gone over enough we close that issue. If the crate
    needs re-checking again later on we just open a new issue.
+5) (optional) If you have completely cleansed a crate of `unsafe`, add a
+   `#![forbid(unsafe_code)]` attribute to its `src/lib.rs` or `main.rs`
+   and/or an ![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)
+   badge to its README.md. Markdown:
+
+```
+[![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
+```
 
 **Everyone is invited to participate!**
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ Our process is as follows:
 4) Once a crate has been gone over enough we close that issue. If the crate
    needs re-checking again later on we just open a new issue.
 5) (Optional) If you have completely cleansed a crate of `unsafe`, add a
-   `#![forbid(unsafe_code)]` attribute to its `src/lib.rs` or `main.rs`
-   and/or an ![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)
-   badge to its README.md. Markdown:
+   `#![forbid(unsafe_code)]` attribute to its `src/lib.rs` or `main.rs`.
+   After doing that, help others discover Safety Dance by adding a badge to
+   your README.md: ![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)
+   Markdown:
 
 ```
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Our process is as follows:
    `#![forbid(unsafe_code)]` attribute to its `src/lib.rs` or `main.rs`.
    After doing that, help others discover Safety Dance by adding a badge to
    your README.md: ![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)
-   Markdown:
+
+Markdown code:
 
 ```
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 This is a place for people to communicate about `unsafe` code in Rust crates.
 
+**Everyone is invited to participate!**
+
+You **do not** have to be an `unsafe` expert to help out. There's a lot of work
+to do just picking crates (ones with a lot of reverse-dependencies are best),
+and then sorting out where they use `unsafe` and why. If you think something
+isn't right just post it in the tracking issue and others can have a look and
+talk it out.
+
+## Process
+
 Our process is as follows:
 
 1) File a tracking issue _in this repo_ about a particular crate, giving its
@@ -46,11 +56,3 @@ Our process is as follows:
 ```
 [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 ```
-
-**Everyone is invited to participate!**
-
-You **do not** have to be an `unsafe` expert to help out. There's a lot of work
-to do just picking crates (ones with a lot of reverse-dependencies are best),
-and then sorting out where they use `unsafe` and why. If you think something
-isn't right just post it in the tracking issue and others can have a look and
-talk it out.


### PR DESCRIPTION
This adds a 5th optional item for crates that complete the process to add a `#![forbid(unsafe_code)]` attribute to crates which have been completely cleansed of `unsafe`, as well the Markdown code to add an [![Safety Dance](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) badge to their README.md.

I think the latter in particular has neat "viral" potential for raising awareness in the project.