### PR TITLE
Suggest consulting #black-magic on Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Our process is as follows:
   * Once you know where the `unsafe` blocks are it gets harder: you have to
     carefully determine if the `unsafe` is being used appropriately. If you
     don't know that's okay, post the questionable block in a comment in the
-    tracking issue here and someone else can have a look too.
+    tracking issue here  and someone else can have a look too, or ask in
+    `#black-magic` on [Rust Community Discord](https://discord.gg/aVESxV8).
 3) When problems are found with an `unsafe` block we want to file bug reports in
    that crate's repo, send PRs with fixes if possible, and also write up
    [security advisories](https://github.com/RustSec/advisory-db) if necessary.


### PR DESCRIPTION
`#black-magic` on Rust Community Discord has been _the_ chat channel for the project so far. I've cleared this with the folks hanging out in there.