### PR TITLE
[WIP] add image crate to trophy case

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Markdown code:
 
 Check out the safety improvements already done!
 
+### [image](https://crates.io/crates/image)
+
+Image operations and conversions to/from image formats ([tracking issue](https://github.com/rust-secure-code/safety-dance/issues/3))
+
+- Unsafe blocks before: **9** (1 of them unsound)
+- Unsafe blocks after: **6**
+- **Security bug fixed:** TODO: wait for https://github.com/RustSec/advisory-db/pull/135 to get RUSTSEC ID assigned
+
+The remaining unsafe blocks are inherent and cannot be removed. They have been audited and found to be sound.
+
+Done by: [HeroicKatora](https://github.com/HeroicKatora), [64](https://github.com/64)
+
 ### [libflate](https://crates.io/crates/libflate)
 
 Popular DEFLATE compression/decompression library ([tracking issue](https://github.com/rust-secure-code/safety-dance/issues/1))

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Check out the safety improvements already done!
 
 Image operations and conversions to/from image formats ([tracking issue](https://github.com/rust-secure-code/safety-dance/issues/3))
 
-- Unsafe blocks before: **9** (1 of them unsound)
+- Unsafe blocks before: **8** (1 of them unsound)
 - Unsafe blocks after: **6**
 - **Security bug fixed:** TODO: wait for https://github.com/RustSec/advisory-db/pull/135 to get RUSTSEC ID assigned
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Check out the safety improvements already done!
 
 Image operations and conversions to/from image formats ([tracking issue](https://github.com/rust-secure-code/safety-dance/issues/3))
 
-- Unsafe blocks before: **8** (1 of them unsound)
+- Unsafe blocks before: **21** (many of them unsound)
 - Unsafe blocks after: **6**
 - **Security bug fixed: [RUSTSEC-2019-0014](https://rustsec.org/advisories/RUSTSEC-2019-0014.html)**
 
 The remaining unsafe blocks are inherent and cannot be removed. They have been audited and found to be sound.
 
-Done by: [HeroicKatora](https://github.com/HeroicKatora), [64](https://github.com/64)
+Done by: [fintelia](https://github.com/fintelia), [HeroicKatora](https://github.com/HeroicKatora), [64](https://github.com/64)
 
 ### [libflate](https://crates.io/crates/libflate)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Image operations and conversions to/from image formats ([tracking issue](https:/
 
 - Unsafe blocks before: **8** (1 of them unsound)
 - Unsafe blocks after: **6**
-- **Security bug fixed:** TODO: wait for https://github.com/RustSec/advisory-db/pull/135 to get RUSTSEC ID assigned
+- **Security bug fixed: [RUSTSEC-2019-0014](https://rustsec.org/advisories/RUSTSEC-2019-0014.html)**
 
 The remaining unsafe blocks are inherent and cannot be removed. They have been audited and found to be sound.
 


### PR DESCRIPTION
`image` crate is audited, unsafe code removed as much as possible. Tracking issue #3 is closed. Just waiting on https://github.com/RustSec/advisory-db/pull/135 before this can be merged.

@HeroicKatora I know you've done a lot of work on making `image` safer. I'd be glad to recognize it here if that's OK with you. I'm only counting the unsafety identified by @64 here right now. 