### PR TITLE
README.md: Fix markdown for nested lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,35 +22,35 @@ Our process is as follows:
 1) File a tracking issue _in this repo_ about a particular crate, giving its
    name and a link to their github (or other repository location).
 2) Audit `unsafe` usage in that crate.
-  * This is easy to start! Note that the GitHub search isn't very good, so it's
-    best to clone the project and use an editor on your own computer. The
-    [cargo geiger](https://github.com/anderejd/cargo-geiger) command can also
-    help here.
-  * Once you know where the `unsafe` blocks are it gets harder: you have to
-    carefully determine if the `unsafe` is being used appropriately. We've been
-    [requesting Clippy lints](https://github.com/rust-secure-code/safety-dance/issues/21)
-    for known antipatterns, so running `cargo +nightly clippy` is a good
-    starting point. If you don't know if a certain `unsafe` block is okay,
-    post the questionable block in a comment in the tracking issue here
-    and someone else can have a look too, or ask in
-    `#black-magic` on [Rust Community Discord](https://discord.gg/aVESxV8).
+    * This is easy to start! Note that the GitHub search isn't very good, so it's
+      best to clone the project and use an editor on your own computer. The
+      [cargo geiger](https://github.com/anderejd/cargo-geiger) command can also
+      help here.
+    * Once you know where the `unsafe` blocks are it gets harder: you have to
+      carefully determine if the `unsafe` is being used appropriately. We've been
+      [requesting Clippy lints](https://github.com/rust-secure-code/safety-dance/issues/21)
+      for known antipatterns, so running `cargo +nightly clippy` is a good
+      starting point. If you don't know if a certain `unsafe` block is okay,
+      post the questionable block in a comment in the tracking issue here
+      and someone else can have a look too, or ask in
+      `#black-magic` on [Rust Community Discord](https://discord.gg/aVESxV8).
 3) When problems are found with an `unsafe` block we want to file bug reports in
    that crate's repo, send PRs with fixes if possible, and also write up
    [security advisories](https://github.com/RustSec/advisory-db) if necessary.
-  * If the `unsafe` block is sound, but can be converted to safe code without
-    losing performance, that's a great thing to do! This is often the case
-    thanks to Rust adding new safe abstractions and improving the optimizer
-    since the code was originally written.
-  * It's possible that `unsafe` can't be eliminated without a performance
-    loss. Unfortunate, but it will happen some of the time. Note that benchmarks
-    _must_ actually be used to back up any performance loss claims. There are
-    already many cases where switching from `unsafe` to safe alternatives has
-    _increased_ performance, so simply guessing that performance will regress
-    is not enough.
-  * If switching away from unsafe is impossible because of missing abstractions
-    then that's important to know! We can work on improving the language, the
-    standard library, and/or the crates.io ecosystem until the necessary gaps
-    are filled in.
+    * If the `unsafe` block is sound, but can be converted to safe code without
+      losing performance, that's a great thing to do! This is often the case
+      thanks to Rust adding new safe abstractions and improving the optimizer
+      since the code was originally written.
+    * It's possible that `unsafe` can't be eliminated without a performance
+      loss. Unfortunate, but it will happen some of the time. Note that benchmarks
+      _must_ actually be used to back up any performance loss claims. There are
+      already many cases where switching from `unsafe` to safe alternatives has
+      _increased_ performance, so simply guessing that performance will regress
+      is not enough.
+    * If switching away from unsafe is impossible because of missing abstractions
+      then that's important to know! We can work on improving the language, the
+      standard library, and/or the crates.io ecosystem until the necessary gaps
+      are filled in.
 4) Once a crate has been gone over enough we close that issue. If the crate
    needs re-checking again later on we just open a new issue.
 5) (Optional) If you have completely cleansed a crate of `unsafe`, add a


### PR DESCRIPTION
These bullet points need to be indented one more level in order for the resulting lists to be nested under each item in the ordered list.